### PR TITLE
Set up automatic dependency upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+---
+version: 2
+
+updates:
+  - package-ecosystem: "cargo"
+    directory: "src/lunaria"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "jdno"
+    reviewers:
+      - "jdno"
+
+  - package-ecosystem: "cargo"
+    directory: "src/lunaria-api"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "jdno"
+    reviewers:
+      - "jdno"


### PR DESCRIPTION
Automatic dependency upgrades have been set up through Dependabot.
Dependabot will open a pull request whenever a new version of a
dependency is released. PRs are automatically assigned to @jdno.