### PR TITLE
Publish crates to package repository

### DIFF
--- a/src/lunaria-api/Cargo.toml
+++ b/src/lunaria-api/Cargo.toml
@@ -4,12 +4,24 @@ version = "0.0.0"
 authors = [
     "Lunaria Contributors",
     "Jan David Nose <jandavid@playlunaria.com>",
-    "Rob Pando <rob@playlunaria.com"
 ]
 edition = "2018"
 
 # See more keys and their definitions at
 # https://doc.rust-lang.org/cargo/reference/manifest.html
+
+description = "A Rust API client for the video game Lunaria"
+homepage = "https://playlunaria.com"
+repository = "https://github.com/playlunaria/lunaria"
+license = "MIT OR Apache-2.0"
+keywords = [
+    "game",
+    "gamedev",
+]
+categories = [
+    "api-bindings",
+    "games"
+]
 
 [dependencies]
 prost = "0.6.1"

--- a/src/lunaria/Cargo.toml
+++ b/src/lunaria/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 # https://doc.rust-lang.org/cargo/reference/manifest.html
 
 description = "A space-themed sandbox video game for programmers"
-readme = "README.md"
 homepage = "https://playlunaria.com"
 repository = "https://github.com/playlunaria/lunaria"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
The `lunaria` and `lunaria-api` crates are being published to crates.io,
Rust's package repository. The version is still set to 0.0.0, since the
crates contain no user-facing functionality yet.