### PR TITLE
Configure Dependabot for the workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,16 +3,7 @@ version: 2
 
 updates:
   - package-ecosystem: "cargo"
-    directory: "src/lunaria"
-    schedule:
-      interval: "daily"
-    assignees:
-      - "jdno"
-    reviewers:
-      - "jdno"
-
-  - package-ecosystem: "cargo"
-    directory: "src/lunaria-api"
+    directory: "/"
     schedule:
       interval: "daily"
     assignees:


### PR DESCRIPTION
Dependabot apparently also supports Cargo workspaces, which is requires
since the lock file will not get updated otherwise. This has caused
build failures and quite some headache in #5.