### PR TITLE
Set up preview builds for beta and nightly

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,5 +1,5 @@
 ---
-name: Nightly
+name: Preview
 
 on:
   schedule:
@@ -7,9 +7,12 @@ on:
 
 jobs:
   test:
-    name: Test
+    name: Preview
     strategy:
       matrix:
+        channel:
+          - beta
+          - nightly
         os:
           - macos
           - ubuntu
@@ -17,6 +20,12 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
 
     steps:
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update && sudo apt-get install -y \
+          alsa \
+          libasound2-dev
+
       - name: Checkout code
         uses: actions/checkout@v2
 
@@ -24,28 +33,28 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.cargo/registry
-          key: ${{ runner.os }}-nightly-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-nightly-cargo-registry-v1-
+          key: ${{ runner.os }}-${{ matrix.channel }}-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.channel }}-cargo-registry-v1-
 
       - name: Cache cargo index
         uses: actions/cache@v1
         with:
           path: ~/.cargo/git
-          key: ${{ runner.os }}-nightly-cargo-index-v1-${{ hashFiles('Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-nightly-cargo-index-v1-
+          key: ${{ runner.os }}-${{ matrix.channel }}-cargo-index-v1-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.channel }}-cargo-index-v1-
 
       - name: Cache cargo build
         uses: actions/cache@v1
         with:
           path: target
-          key: ${{ runner.os }}-nightly-cargo-build-target-v1-${{ hashFiles('Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-nightly-cargo-build-target-v1-
+          key: ${{ runner.os }}-${{ matrix.channel }}-cargo-build-target-v1-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.channel }}-cargo-build-target-v1-
 
       - name: Set up Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: ${{ matrix.channel }}
           override: true
 
       - name: Run tests


### PR DESCRIPTION
Preview builds have been set up to run every night for Rust's nightly
and beta channels. This is done to get early signals if new features in
Rust break any functionality in Lunaria.