### PR TITLE
Install build dependencies for preview builds

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   preview:
-    name: Preview (ubuntu)
+    name: Preview
     strategy:
       matrix:
         channel:
@@ -46,7 +46,6 @@ jobs:
       - name: Set up Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: ${{ matrix.channel }}
           override: true
 
@@ -70,7 +69,8 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y \
           alsa \
-          libasound2-dev
+          libasound2-dev \
+          libudev-dev
 
       - name: Checkout code
         uses: actions/checkout@v2
@@ -99,7 +99,6 @@ jobs:
       - name: Set up Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: ${{ matrix.channel }}
           override: true
 

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -120,6 +120,8 @@ jobs:
 
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@master
+        with:
+          version: 0.13.3
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1.0.2

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -85,7 +85,8 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y \
           alsa \
-          libasound2-dev
+          libasound2-dev \
+          libudev-dev
 
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Preview builds were missing some of the system-level dependency needed
to compile the project.