### PR TITLE
Disable caching in macOS builds

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -22,14 +22,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-${{ matrix.channel }}-cargo-v1-${{ hashFiles('Cargo.lock') }}
-
       - name: Set up Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -62,14 +54,6 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v2
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-${{ matrix.channel }}-cargo-v1-${{ hashFiles('Cargo.lock') }}
 
       - name: Set up Rust toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -121,14 +121,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-${{ matrix.channel }}-cargo-v1-${{ hashFiles('Cargo.lock') }}
-
       - name: Set up Rust toolchain
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
We are experiencing intermittent build failures of macOS builds on
GitHub Actions. Similar issues have been reported by others
maintainers before, and a good summary of the issue can be found in the
[actions-rs/cargo] repository.

As a temporary workaround, caching is disabled for macOS builds.

[actions-rs/cargo]: https://github.com/actions-rs/cargo/issues/111