### PR TITLE
Run API in background thread

### DIFF
--- a/src/lunaria-godot/src/engine.rs
+++ b/src/lunaria-godot/src/engine.rs
@@ -1,13 +1,22 @@
 use gdnative::prelude::*;
 
+use lunaria::engine::Engine;
+
 #[derive(NativeClass)]
 #[inherit(Node)]
-pub struct EngineSingleton {}
+pub struct EngineSingleton {
+    _engine: Engine,
+}
 
 #[methods]
 impl EngineSingleton {
     fn new(_owner: &Node) -> Self {
-        Self {}
+        let engine = match Engine::new() {
+            Ok(engine) => engine,
+            Err(error) => panic!("{}", error),
+        };
+
+        Self { _engine: engine }
     }
 
     #[export]

--- a/src/lunaria/src/api.rs
+++ b/src/lunaria/src/api.rs
@@ -17,14 +17,13 @@ impl Api {
         Self::default()
     }
 
-    pub fn run(&self) {
+    pub async fn serve(self) -> Result<(), tonic::transport::Error> {
         let address = self.address_or_default();
 
-        tokio::spawn(
-            GrpcServer::builder()
-                .add_service(LunariaServiceServer::new(LunariaService::default()))
-                .serve(address),
-        );
+        GrpcServer::builder()
+            .add_service(LunariaServiceServer::new(LunariaService::default()))
+            .serve(address)
+            .await
     }
 
     fn address_or_default(&self) -> SocketAddr {

--- a/src/lunaria/src/engine.rs
+++ b/src/lunaria/src/engine.rs
@@ -1,0 +1,37 @@
+use getset::Getters;
+use tokio::runtime::Runtime;
+
+use crate::api::Api;
+use crate::error::{Code, Error, ErrorKind, Result};
+
+#[derive(Getters)]
+pub struct Engine {
+    #[getset(get = "pub")]
+    runtime: Runtime,
+}
+
+impl Engine {
+    pub fn new() -> Result<Self> {
+        let runtime = initialize_runtime()?;
+        let api = initialize_api();
+
+        runtime.spawn(api.serve());
+
+        Ok(Self { runtime })
+    }
+}
+
+fn initialize_api() -> Api {
+    Api::new()
+}
+
+fn initialize_runtime() -> Result<Runtime> {
+    match Runtime::new() {
+        Ok(runtime) => Ok(runtime),
+        Err(error) => Err(Error::new(
+            Code::new("LUN0001"),
+            ErrorKind::Runtime,
+            &format!("Failed to initialize the runtime. {}", error),
+        )),
+    }
+}

--- a/src/lunaria/src/error.rs
+++ b/src/lunaria/src/error.rs
@@ -63,6 +63,9 @@ impl Display for Code {
 pub enum ErrorKind {
     /// An error of unknown origin
     Unknown,
+
+    /// An error with the asynchronous runtime that runs Lunaria's background processing
+    Runtime,
 }
 
 #[cfg(test)]

--- a/src/lunaria/src/lib.rs
+++ b/src/lunaria/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod api;
+pub mod engine;
 pub mod error;


### PR DESCRIPTION
The API is now running in a background thread when the game is started.
The engine singleton starts a tokio runtime, and spawns the gRPC server
on it.