### PR TITLE
Remove needless borrow

### DIFF
--- a/src/lunaria/src/error.rs
+++ b/src/lunaria/src/error.rs
@@ -49,7 +49,7 @@ impl Code {
     }
 
     pub fn get(&self) -> &str {
-        &self.0
+        self.0
     }
 }
 


### PR DESCRIPTION
After upgrading Rust to 1.54.0, Clippy warns about a needless borrow in
the custom error class.