### PR TITLE
Stream game status updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,6 +539,7 @@ dependencies = [
  "getset",
  "lunaria-api",
  "tokio",
+ "tokio-stream",
  "tonic",
  "uuid",
 ]
@@ -560,6 +561,8 @@ version = "0.0.0"
 dependencies = [
  "gdnative",
  "lunaria",
+ "strum",
+ "tokio",
 ]
 
 [[package]]
@@ -1036,6 +1039,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,13 +1124,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.1"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4cdeb73537e63f98adcd73138af75e3f368ccaecffaa29d7eb61b9f5a440457"
+checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
 dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/godot/scenes/game/Game.gdns
+++ b/godot/scenes/game/Game.gdns
@@ -1,0 +1,8 @@
+[gd_resource type="NativeScript" load_steps=2 format=2]
+
+[ext_resource path="res://libraries/Lunaria.tres" type="GDNativeLibrary" id=1]
+
+[resource]
+resource_name = "GameScene"
+class_name = "GameScene"
+library = ExtResource( 1 )

--- a/godot/scenes/game/Game.tscn
+++ b/godot/scenes/game/Game.tscn
@@ -1,9 +1,11 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://assets/textures/Ground.tres" type="TileSet" id=1]
 [ext_resource path="res://scenes/game/GameCamera.gd" type="Script" id=2]
+[ext_resource path="res://scenes/game/Game.gdns" type="Script" id=3]
 
 [node name="GameScene" type="Node2D"]
+script = ExtResource( 3 )
 
 [node name="GameCamera" type="Camera2D" parent="."]
 current = true

--- a/src/lunaria-godot/Cargo.toml
+++ b/src/lunaria-godot/Cargo.toml
@@ -30,3 +30,5 @@ crate-type = ["cdylib"]
 lunaria = { path = "../lunaria", version = "0.0.0" }
 
 gdnative = "0.9.3"
+strum = { version = "0.21.0", features = ["derive"] }
+tokio = { version = "1.9.0" }

--- a/src/lunaria-godot/src/engine.rs
+++ b/src/lunaria-godot/src/engine.rs
@@ -1,26 +1,48 @@
 use gdnative::prelude::*;
+use tokio::sync::watch::{channel, Sender};
 
 use lunaria::engine::Engine;
+use lunaria::game::GameStatus;
 
 #[derive(NativeClass)]
 #[inherit(Node)]
 pub struct EngineSingleton {
     _engine: Engine,
+    game_status_sender: Sender<GameStatus>,
 }
 
 #[methods]
 impl EngineSingleton {
     fn new(_owner: &Node) -> Self {
-        let engine = match Engine::new() {
+        let (sender, receiver) = channel(GameStatus::Stopped);
+
+        let engine = match Engine::new(receiver) {
             Ok(engine) => engine,
             Err(error) => panic!("{}", error),
         };
 
-        Self { _engine: engine }
+        Self {
+            _engine: engine,
+            game_status_sender: sender,
+        }
     }
 
     #[export]
     fn _ready(&self, _owner: &Node) {
         godot_print!("Engine ready");
+    }
+
+    #[export]
+    fn on_game_status_running(&self, _owner: TRef<Node>) {
+        if self.game_status_sender.send(GameStatus::Running).is_err() {
+            // TODO: Log error
+        }
+    }
+
+    #[export]
+    fn on_game_status_stopped(&self, _owner: TRef<Node>) {
+        if self.game_status_sender.send(GameStatus::Stopped).is_err() {
+            // TODO: Log error
+        }
     }
 }

--- a/src/lunaria-godot/src/lib.rs
+++ b/src/lunaria-godot/src/lib.rs
@@ -1,12 +1,17 @@
 use gdnative::prelude::*;
 
 use crate::engine::EngineSingleton;
+use crate::scenes::game::GameScene;
 
 mod engine;
+mod scenes;
 
 fn init(handle: InitHandle) {
     // Singletons
     handle.add_class::<EngineSingleton>();
+
+    // Scenes
+    handle.add_class::<GameScene>();
 }
 
 godot_init!(init);

--- a/src/lunaria-godot/src/scenes.rs
+++ b/src/lunaria-godot/src/scenes.rs
@@ -1,0 +1,1 @@
+pub mod game;

--- a/src/lunaria-godot/src/scenes/game.rs
+++ b/src/lunaria-godot/src/scenes/game.rs
@@ -1,0 +1,61 @@
+use gdnative::prelude::*;
+use strum::IntoEnumIterator;
+use strum::{AsRefStr, EnumIter};
+
+#[derive(AsRefStr, EnumIter, Debug)]
+pub enum GameStatusSignal {
+    Running,
+    Stopped,
+}
+
+#[derive(NativeClass)]
+#[inherit(Node)]
+#[register_with(Self::register_signals)]
+pub struct GameScene {}
+
+#[methods]
+impl GameScene {
+    pub fn new(_owner: &Node) -> Self {
+        Self {}
+    }
+
+    #[export]
+    fn _ready(&mut self, owner: TRef<Node>) {
+        self.connect_signals_to_engine(owner);
+        owner.emit_signal(GameStatusSignal::Running.as_ref(), &[]);
+    }
+
+    #[export]
+    fn _exit_tree(&mut self, owner: &Node) {
+        owner.emit_signal(GameStatusSignal::Stopped.as_ref(), &[]);
+    }
+
+    fn register_signals(builder: &ClassBuilder<Self>) {
+        for status in GameStatusSignal::iter() {
+            builder.add_signal(Signal {
+                name: status.as_ref(),
+                args: &[],
+            });
+        }
+    }
+
+    fn connect_signals_to_engine(&self, owner: TRef<Node>) {
+        let signals = vec![
+            (GameStatusSignal::Running.as_ref(), "on_game_status_running"),
+            (GameStatusSignal::Stopped.as_ref(), "on_game_status_stopped"),
+        ];
+
+        if let Some(engine) = &mut owner.get_node("/root/EngineSingleton") {
+            let engine = unsafe { engine.assume_safe() };
+
+            for (signal, method) in signals {
+                match owner.connect(signal, engine, method, VariantArray::new_shared(), 0) {
+                    Ok(_) => (),
+                    Err(error) => {
+                        godot_print!("Failed to connect game running signal to engine. {}", error);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/lunaria/Cargo.toml
+++ b/src/lunaria/Cargo.toml
@@ -27,5 +27,6 @@ lunaria-api = { version = "0.2.0", features = ["server"] }
 
 getset = "0.1.1"
 tokio = { version = "1.9.0", features = ["macros", "rt-multi-thread"] }
+tokio-stream = { version = "0.1.7", features = ["sync"] }
 tonic = "0.5.0"
 uuid = { version = "0.8.2", features = ["v4"] }

--- a/src/lunaria/src/api.rs
+++ b/src/lunaria/src/api.rs
@@ -1,26 +1,38 @@
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 
+use lunaria_api::lunaria::v1::game_service_server::GameServiceServer;
 use lunaria_api::lunaria::v1::lunaria_service_server::LunariaServiceServer;
+use tokio::sync::watch::Receiver;
 use tonic::transport::Server as GrpcServer;
 
+use crate::api::game::GameService;
 use crate::api::lunaria::LunariaService;
+use crate::game::GameStatus;
 
 const ENV_VAR_ADDRESS: &str = "LUNARIA_ADDRESS";
 
+pub mod game;
 pub mod lunaria;
 
-pub struct Api;
+pub struct Api {
+    game_status_receiver: Receiver<GameStatus>,
+}
 
 impl Api {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(game_status_receiver: Receiver<GameStatus>) -> Self {
+        Self {
+            game_status_receiver,
+        }
     }
 
     pub async fn serve(self) -> Result<(), tonic::transport::Error> {
         let address = self.address_or_default();
 
         GrpcServer::builder()
+            .add_service(GameServiceServer::new(GameService::new(
+                self.game_status_receiver.clone(),
+            )))
             .add_service(LunariaServiceServer::new(LunariaService::default()))
             .serve(address)
             .await
@@ -34,11 +46,5 @@ impl Api {
         }
 
         SocketAddr::new(IpAddr::from([0, 0, 0, 0]), 1904)
-    }
-}
-
-impl Default for Api {
-    fn default() -> Self {
-        Self {}
     }
 }

--- a/src/lunaria/src/api/game.rs
+++ b/src/lunaria/src/api/game.rs
@@ -1,0 +1,46 @@
+use std::pin::Pin;
+
+use lunaria_api::lunaria::v1::start_game_response::GameStatus as ApiGameStatus;
+use lunaria_api::lunaria::v1::{StartGameRequest, StartGameResponse};
+use tokio::sync::watch::Receiver;
+use tokio_stream::wrappers::WatchStream;
+use tokio_stream::StreamExt;
+use tonic::codegen::futures_core::Stream;
+use tonic::{Request, Response, Status};
+
+use crate::game::GameStatus;
+
+pub struct GameService {
+    receiver: Receiver<GameStatus>,
+}
+
+impl GameService {
+    pub fn new(receiver: Receiver<GameStatus>) -> Self {
+        Self { receiver }
+    }
+}
+
+#[tonic::async_trait]
+impl lunaria_api::lunaria::v1::game_service_server::GameService for GameService {
+    type StartGameStream =
+        Pin<Box<dyn Stream<Item = Result<StartGameResponse, Status>> + Send + Sync + 'static>>;
+
+    async fn start_game(
+        &self,
+        _request: Request<StartGameRequest>,
+    ) -> Result<Response<Self::StartGameStream>, Status> {
+        let stream = WatchStream::new(self.receiver.clone()).map(|status| match status {
+            GameStatus::Loading => Ok(StartGameResponse {
+                status: ApiGameStatus::Loading.into(),
+            }),
+            GameStatus::Running => Ok(StartGameResponse {
+                status: ApiGameStatus::Running.into(),
+            }),
+            GameStatus::Stopped => Ok(StartGameResponse {
+                status: ApiGameStatus::Stopped.into(),
+            }),
+        });
+
+        Ok(Response::new(Box::pin(stream) as Self::StartGameStream))
+    }
+}

--- a/src/lunaria/src/engine.rs
+++ b/src/lunaria/src/engine.rs
@@ -1,8 +1,10 @@
 use getset::Getters;
 use tokio::runtime::Runtime;
+use tokio::sync::watch::Receiver;
 
 use crate::api::Api;
 use crate::error::{Code, Error, ErrorKind, Result};
+use crate::game::GameStatus;
 
 #[derive(Getters)]
 pub struct Engine {
@@ -11,18 +13,14 @@ pub struct Engine {
 }
 
 impl Engine {
-    pub fn new() -> Result<Self> {
+    pub fn new(game_status_receiver: Receiver<GameStatus>) -> Result<Self> {
         let runtime = initialize_runtime()?;
-        let api = initialize_api();
+        let api = Api::new(game_status_receiver);
 
         runtime.spawn(api.serve());
 
         Ok(Self { runtime })
     }
-}
-
-fn initialize_api() -> Api {
-    Api::new()
 }
 
 fn initialize_runtime() -> Result<Runtime> {

--- a/src/lunaria/src/game.rs
+++ b/src/lunaria/src/game.rs
@@ -1,0 +1,6 @@
+#[derive(Clone, Copy, Debug)]
+pub enum GameStatus {
+    Loading,
+    Running,
+    Stopped,
+}

--- a/src/lunaria/src/lib.rs
+++ b/src/lunaria/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod api;
 pub mod engine;
 pub mod error;
+pub mod game;


### PR DESCRIPTION
The new API to stream game status updates has been hooked up within the game. When a new game is started or stopped, a status update is streamed to connected clients. The engine listens to signals from Godot, and converts them to gRPC messages.


https://user-images.githubusercontent.com/865550/127554087-a9049336-e2b4-44ea-807c-a2edadd9cfc9.mov

