### PR TITLE
Add command and event queues

### DIFF
--- a/src/lunaria/src/engine.rs
+++ b/src/lunaria/src/engine.rs
@@ -1,10 +1,12 @@
 use getset::Getters;
 use tokio::runtime::Runtime;
+use tokio::sync::mpsc::Sender;
 use tokio::sync::watch::Receiver;
 
 use crate::api::Api;
+use crate::command::Command;
 use crate::error::{Code, Error, ErrorKind, Result};
-use crate::game::GameStatus;
+use crate::event::Event;
 
 #[derive(Getters)]
 pub struct Engine {
@@ -12,10 +14,13 @@ pub struct Engine {
     runtime: Runtime,
 }
 
+pub type CommandQueue = Sender<Command>;
+pub type EventQueue = Receiver<Event>;
+
 impl Engine {
-    pub fn new(game_status_receiver: Receiver<GameStatus>) -> Result<Self> {
+    pub fn new(command_queue: CommandQueue, event_queue: EventQueue) -> Result<Self> {
         let runtime = initialize_runtime()?;
-        let api = Api::new(game_status_receiver);
+        let api = Api::new(command_queue, event_queue);
 
         runtime.spawn(api.serve());
 

--- a/src/lunaria/src/event.rs
+++ b/src/lunaria/src/event.rs
@@ -1,4 +1,6 @@
+#[derive(Clone)]
 pub enum Event {
+    None,
     GameStarted,
     GameFinished,
 }

--- a/src/lunaria/src/game.rs
+++ b/src/lunaria/src/game.rs
@@ -1,6 +1,0 @@
-#[derive(Clone, Copy, Debug)]
-pub enum GameStatus {
-    Loading,
-    Running,
-    Stopped,
-}

--- a/src/lunaria/src/lib.rs
+++ b/src/lunaria/src/lib.rs
@@ -3,4 +3,3 @@ pub mod command;
 pub mod engine;
 pub mod error;
 pub mod event;
-pub mod game;


### PR DESCRIPTION
Two queues have been added to the engine. The command queue allows
clients to send instructions to the game engine. The result of these
commands is sent back from the engine through an event.