### PR TITLE
Update API crate and implement synchronous start game command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "lunaria-api"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e45a069929ebcb8211788164d5ac8e013eda63b42e0c6c2b5ad54e9d502c9d"
+checksum = "a5cfc86d458d1dff5b40a8b6b46bb32e4569b1a747236ab6cbb8c12ff7dc748a"
 dependencies = [
  "prost",
  "tonic",

--- a/src/lunaria-godot/src/engine.rs
+++ b/src/lunaria-godot/src/engine.rs
@@ -1,18 +1,17 @@
 use gdnative::prelude::*;
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{broadcast, watch};
 
 use lunaria::command::Command;
 use lunaria::engine::Engine;
 use lunaria::event::Event;
 
-type CommandQueue = mpsc::Receiver<Command>;
+type CommandQueue = broadcast::Receiver<Command>;
 type EventQueue = watch::Sender<Event>;
 
 #[derive(NativeClass)]
 #[inherit(Node)]
 pub struct EngineSingleton {
     _engine: Engine,
-    #[allow(dead_code)] // TODO: Remove when switching to synchronous start command
     command_queue: CommandQueue,
     event_queue: EventQueue,
 }
@@ -20,10 +19,10 @@ pub struct EngineSingleton {
 #[methods]
 impl EngineSingleton {
     fn new(_owner: &Node) -> Self {
-        let (command_sender, command_receiver) = mpsc::channel(256);
-        let (event_sender, event_receiver) = watch::channel(Event::None);
+        let (command_sender, command_receiver) = broadcast::channel(256);
+        let (event_sender, _event_receiver) = watch::channel(Event::None);
 
-        let engine = match Engine::new(command_sender, event_receiver) {
+        let engine = match Engine::new(command_sender) {
             Ok(engine) => engine,
             Err(error) => panic!("{}", error),
         };
@@ -41,6 +40,15 @@ impl EngineSingleton {
     }
 
     #[export]
+    fn _process(&mut self, owner: TRef<Node>, _delta: f32) {
+        while let Ok(command) = self.command_queue.try_recv() {
+            match command {
+                Command::StartGame => self.start_game(owner),
+            }
+        }
+    }
+
+    #[export]
     fn on_game_status_running(&self, _owner: TRef<Node>) {
         if self.event_queue.send(Event::GameStarted).is_err() {
             // TODO: Log error
@@ -51,6 +59,16 @@ impl EngineSingleton {
     fn on_game_status_stopped(&self, _owner: TRef<Node>) {
         if self.event_queue.send(Event::GameFinished).is_err() {
             // TODO: Log error
+        }
+    }
+
+    fn start_game(&self, owner: TRef<Node>) {
+        if let Some(tree_ref) = owner.get_tree() {
+            let tree = unsafe { tree_ref.assume_safe() };
+
+            if let Err(error) = tree.change_scene("res://scenes/game/Game.tscn") {
+                panic!("Failed to switch to game scene. {}", error);
+            }
         }
     }
 }

--- a/src/lunaria/Cargo.toml
+++ b/src/lunaria/Cargo.toml
@@ -23,7 +23,7 @@ categories = [
 ]
 
 [dependencies]
-lunaria-api = { version = "0.2.0", features = ["server"] }
+lunaria-api = { version = "0.2.1", features = ["server"] }
 
 getset = "0.1.1"
 tokio = { version = "1.10.0", features = ["macros", "rt-multi-thread"] }

--- a/src/lunaria/src/api.rs
+++ b/src/lunaria/src/api.rs
@@ -7,7 +7,7 @@ use tonic::transport::Server as GrpcServer;
 
 use crate::api::game::GameService;
 use crate::api::lunaria::LunariaService;
-use crate::engine::{CommandQueue, EventQueue};
+use crate::engine::CommandQueue;
 
 const ENV_VAR_ADDRESS: &str = "LUNARIA_ADDRESS";
 
@@ -15,17 +15,12 @@ pub mod game;
 pub mod lunaria;
 
 pub struct Api {
-    #[allow(dead_code)] // TODO: Remove when switching to synchronous start command
     command_queue: CommandQueue,
-    event_queue: EventQueue,
 }
 
 impl Api {
-    pub fn new(command_queue: CommandQueue, event_queue: EventQueue) -> Self {
-        Self {
-            command_queue,
-            event_queue,
-        }
+    pub fn new(command_queue: CommandQueue) -> Self {
+        Self { command_queue }
     }
 
     pub async fn serve(self) -> Result<(), tonic::transport::Error> {
@@ -33,7 +28,7 @@ impl Api {
 
         GrpcServer::builder()
             .add_service(GameServiceServer::new(GameService::new(
-                self.event_queue.clone(),
+                self.command_queue.clone(),
             )))
             .add_service(LunariaServiceServer::new(LunariaService::default()))
             .serve(address)

--- a/src/lunaria/src/api/game.rs
+++ b/src/lunaria/src/api/game.rs
@@ -1,46 +1,28 @@
-use std::pin::Pin;
-
-use lunaria_api::lunaria::v1::start_game_response::GameStatus as ApiGameStatus;
 use lunaria_api::lunaria::v1::{StartGameRequest, StartGameResponse};
-use tokio_stream::wrappers::WatchStream;
-use tokio_stream::StreamExt;
-use tonic::codegen::futures_core::Stream;
 use tonic::{Request, Response, Status};
 
-use crate::engine::EventQueue;
-use crate::event::Event;
+use crate::command::Command;
+use crate::engine::CommandQueue;
 
 pub struct GameService {
-    event_queue: EventQueue,
+    command_queue: CommandQueue,
 }
 
 impl GameService {
-    pub fn new(event_queue: EventQueue) -> Self {
-        Self { event_queue }
+    pub fn new(command_queue: CommandQueue) -> Self {
+        Self { command_queue }
     }
 }
 
 #[tonic::async_trait]
 impl lunaria_api::lunaria::v1::game_service_server::GameService for GameService {
-    type StartGameStream =
-        Pin<Box<dyn Stream<Item = Result<StartGameResponse, Status>> + Send + Sync + 'static>>;
-
     async fn start_game(
         &self,
         _request: Request<StartGameRequest>,
-    ) -> Result<Response<Self::StartGameStream>, Status> {
-        let stream = WatchStream::new(self.event_queue.clone()).map(|status| match status {
-            Event::None => Ok(StartGameResponse {
-                status: ApiGameStatus::Unspecified.into(),
-            }),
-            Event::GameStarted => Ok(StartGameResponse {
-                status: ApiGameStatus::Running.into(),
-            }),
-            Event::GameFinished => Ok(StartGameResponse {
-                status: ApiGameStatus::Stopped.into(),
-            }),
-        });
-
-        Ok(Response::new(Box::pin(stream) as Self::StartGameStream))
+    ) -> Result<Response<StartGameResponse>, Status> {
+        match self.command_queue.send(Command::StartGame) {
+            Ok(_) => Ok(Response::new(StartGameResponse {})),
+            Err(error) => Err(Status::internal(error.to_string())),
+        }
     }
 }

--- a/src/lunaria/src/command.rs
+++ b/src/lunaria/src/command.rs
@@ -1,3 +1,4 @@
+#[derive(Clone)]
 pub enum Command {
     StartGame,
 }

--- a/src/lunaria/src/engine.rs
+++ b/src/lunaria/src/engine.rs
@@ -1,12 +1,10 @@
 use getset::Getters;
 use tokio::runtime::Runtime;
-use tokio::sync::mpsc::Sender;
-use tokio::sync::watch::Receiver;
+use tokio::sync::broadcast::Sender;
 
 use crate::api::Api;
 use crate::command::Command;
 use crate::error::{Code, Error, ErrorKind, Result};
-use crate::event::Event;
 
 #[derive(Getters)]
 pub struct Engine {
@@ -15,12 +13,11 @@ pub struct Engine {
 }
 
 pub type CommandQueue = Sender<Command>;
-pub type EventQueue = Receiver<Event>;
 
 impl Engine {
-    pub fn new(command_queue: CommandQueue, event_queue: EventQueue) -> Result<Self> {
+    pub fn new(command_queue: CommandQueue) -> Result<Self> {
         let runtime = initialize_runtime()?;
-        let api = Api::new(command_queue, event_queue);
+        let api = Api::new(command_queue);
 
         runtime.spawn(api.serve());
 


### PR DESCRIPTION
The API crate has been bumped, and the API server has been updated to
provide the synchronous start game command defined in the API specs. The
command is sent to the engine using a command bus.